### PR TITLE
feat(rum): observe the full page scroll

### DIFF
--- a/pages/scripts/delayed.js
+++ b/pages/scripts/delayed.js
@@ -18,7 +18,13 @@ if (!isProd === 'this') {
 // Core Web Vitals RUM collection
 sampleRUM('cwv');
 
-(new IntersectionObserver(() => sampleRUM('viewfooter'), { threshold: 1 })).observe(document.querySelector('footer'));
+window.onscroll = function(ev) {
+  // we use window.onscroll instead of an intersection observer to avoid the invisible footer triggering the
+  // observer which can happen when the user scrolls very fast.
+  if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight) {
+    sampleRUM('viewfooter', { source: 'footer' });
+  }
+};
 
 // add more delayed functionality here
 window.pgatour = window.pgatour || {};

--- a/pages/scripts/delayed.js
+++ b/pages/scripts/delayed.js
@@ -18,9 +18,9 @@ if (!isProd === 'this') {
 // Core Web Vitals RUM collection
 sampleRUM('cwv');
 
-window.onscroll = function(ev) {
-  // we use window.onscroll instead of an intersection observer to avoid the invisible footer triggering the
-  // observer which can happen when the user scrolls very fast.
+window.onscroll = () => {
+  // we use window.onscroll instead of an intersection observer to avoid the invisible
+  // footer triggering the observer which can happen when the user scrolls very fast.
   if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight) {
     sampleRUM('viewfooter', { source: 'footer' });
   }

--- a/pages/scripts/delayed.js
+++ b/pages/scripts/delayed.js
@@ -18,6 +18,8 @@ if (!isProd === 'this') {
 // Core Web Vitals RUM collection
 sampleRUM('cwv');
 
+(new IntersectionObserver(() => sampleRUM('boink'), { threshold: 1 })).observe(document.body);
+
 // add more delayed functionality here
 window.pgatour = window.pgatour || {};
 window.pgatour.tracking = {

--- a/pages/scripts/delayed.js
+++ b/pages/scripts/delayed.js
@@ -18,7 +18,7 @@ if (!isProd === 'this') {
 // Core Web Vitals RUM collection
 sampleRUM('cwv');
 
-(new IntersectionObserver(() => sampleRUM('boink'), { threshold: 1 })).observe(document.body);
+(new IntersectionObserver(() => sampleRUM('viewfooter'), { threshold: 1 })).observe(document.querySelector('footer'));
 
 // add more delayed functionality here
 window.pgatour = window.pgatour || {};


### PR DESCRIPTION
Test this on:
https://trieloff-patch-1--pgatour-com--hlxsites.hlx.page/pages/genesisinvitational/?rum=on

scroll to the very end, look in the dev console for a log message `ping:viewfooter {source: 'footer'}`

see https://adobe-dx-support.slack.com/archives/C04EW4NVBB5/p1677146110315599?thread_ts=1677092154.395919&cid=C04EW4NVBB5