### PR TITLE
fix: clear the data layer before we load launch

### DIFF
--- a/pages/scripts/delayed.js
+++ b/pages/scripts/delayed.js
@@ -78,8 +78,8 @@ async function OptanonWrapper() {
     localStorage.setItem('OptIn_PreviousPermissions', JSON.stringify(adobeSettings));
   }
 
+  clearDataLayer();
   loadScript(`https://assets.adobedtm.com/d17bac9530d5/a14f7717d75d/launch-aa66aad171be${isProd ? '.min' : ''}.js`, () => {
-    clearDataLayer();
     pushOneTrustConsentGroups();
 
     loadScript('https://cdns.us1.gigya.com/js/gigya.js?apikey=3_IscKmAoYcuwP8zpTnatC3hXBUm8rPuI-Hg_cZJ-jL-M7LgqCkxmwe-ps1Qy7PoWd', () => {


### PR DESCRIPTION
We need to clear data layer of the OOTB OT events, so we can push our own, so that we match what is on the rest of pgatour.com. that clearing has to happen after Ot is loaded, but before launch is loaded, hence the change.

Test URLs:
- Before: https://main--pgatour-com--hlxsites.hlx.live/pages/genesisinvitational/
- After: https://dl-clearfix--pgatour-com--hlxsites.hlx.live/pages/genesisinvitational/
